### PR TITLE
Added silent deploy flag, custom guild prefixs, guild caching

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,6 +223,11 @@
             <artifactId>h2</artifactId>
             <version>1.3.170</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+            <version>4.1</version>
+        </dependency>
     </dependencies>
 
     <repositories>

--- a/src/main/java/com/bot/Main.java
+++ b/src/main/java/com/bot/Main.java
@@ -31,19 +31,16 @@ public class Main {
 			return;
 		}
 
-		boolean useDB = Boolean.parseBoolean(config.getConfig(Config.USE_DB));
-		if (useDB) {
-			ConnectionPool connectionPool = ConnectionPool.getInstance();
-			LOGGER.log(Level.INFO, "Hikari pool successfully initialized");
-			Flyway flyway = new Flyway();
-			flyway.setDataSource(connectionPool.getDataSource());
-			flyway.migrate();
-			LOGGER.log(Level.INFO, "Flyway migrations completed");
-		}
+		ConnectionPool connectionPool = ConnectionPool.getInstance();
+		LOGGER.log(Level.INFO, "Hikari pool successfully initialized");
+		Flyway flyway = new Flyway();
+		flyway.setDataSource(connectionPool.getDataSource());
+		flyway.migrate();
+		LOGGER.log(Level.INFO, "Flyway migrations completed");
 
 		int numShards = Integer.parseInt(config.getConfig(Config.NUM_SHARDS));
 		boolean dataLoader = Boolean.parseBoolean(config.getConfig(Config.DATA_LOADER));
-		ShardingManager shardingManager = ShardingManager.getInstance(numShards, useDB);
+		ShardingManager shardingManager = ShardingManager.getInstance(numShards);
 
 		LOGGER.log(Level.INFO, "Starting a data loader");
 		DataLoader loader = new DataLoader(shardingManager);

--- a/src/main/java/com/bot/commands/general/InviteCommand.java
+++ b/src/main/java/com/bot/commands/general/InviteCommand.java
@@ -1,5 +1,6 @@
 package com.bot.commands.general;
 
+import com.bot.utils.CommandCategories;
 import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
 import net.dv8tion.jda.core.entities.PrivateChannel;
@@ -11,6 +12,7 @@ public class InviteCommand extends Command {
         this.name = "invite";
         this.help = "Sends a link to invite the bot to your server";
         this.arguments = "";
+        this.category = CommandCategories.GENERAL;
     }
 
     @Override

--- a/src/main/java/com/bot/commands/settings/AddPrefixCommand.java
+++ b/src/main/java/com/bot/commands/settings/AddPrefixCommand.java
@@ -1,0 +1,52 @@
+package com.bot.commands.settings;
+
+import com.bot.db.GuildDAO;
+import com.bot.models.InternalGuild;
+import com.bot.utils.CommandCategories;
+import com.bot.utils.GuildUtils;
+import com.jagrosh.jdautilities.command.Command;
+import com.jagrosh.jdautilities.command.CommandEvent;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+public class AddPrefixCommand extends Command {
+
+    private GuildDAO guildDAO;
+
+    public AddPrefixCommand() {
+        this.name = "addprefix";
+        this.help = "Adds one or more custom prefixes to the server.";
+        this.arguments = "<One or more custom prefixes, separated by spaces>";
+        this.guildOnly = true;
+        this.category = CommandCategories.MOD;
+
+        guildDAO = GuildDAO.getInstance();
+    }
+
+    @Override
+    protected void execute(CommandEvent commandEvent) {
+        InternalGuild guild = guildDAO.getGuildById(commandEvent.getGuild().getId());
+
+        if (commandEvent.getArgs().isEmpty()) {
+            commandEvent.reply(commandEvent.getClient().getWarning() + " You must specify at least one custom prefix to add.");
+            return;
+        }
+
+        ArrayList<String> prefixes = guild.getPrefixList();
+        prefixes.addAll(Arrays.asList(commandEvent.getArgs().split(" ")));
+        String newPrefixes = GuildUtils.convertListToPrefixesString(prefixes);
+
+        if (newPrefixes.length() > 254) {
+            commandEvent.reply(commandEvent.getClient().getWarning() + " Failed to add custom prefixes. The length of all" +
+                    " prefixes on the server cannot be more than 250 characters. You can remove custom prefixes with the `removeprefix` command.");
+            return;
+        }
+
+        if (guildDAO.updateGuildPrefixes(commandEvent.getGuild().getId(), prefixes)) {
+            commandEvent.getMessage().addReaction(commandEvent.getClient().getSuccess()).queue();
+        } else {
+            commandEvent.reply(commandEvent.getClient().getError() + " Failed to update prefixes for server. Please contact a developer on the support server if this issue persists.");
+        }
+    }
+}

--- a/src/main/java/com/bot/commands/settings/PrefixesCommand.java
+++ b/src/main/java/com/bot/commands/settings/PrefixesCommand.java
@@ -1,0 +1,43 @@
+package com.bot.commands.settings;
+
+import com.bot.db.GuildDAO;
+import com.bot.models.InternalGuild;
+import com.bot.utils.CommandCategories;
+import com.jagrosh.jdautilities.command.Command;
+import com.jagrosh.jdautilities.command.CommandEvent;
+
+import java.util.List;
+
+public class PrefixesCommand extends Command {
+
+    private GuildDAO guildDAO;
+
+    public PrefixesCommand() {
+        this.name = "prefixes";
+        this.arguments = "";
+        this.help = "Lists all set prefixes for the server.";
+        this.category = CommandCategories.GENERAL;
+        this.guildOnly = true;
+
+        guildDAO = GuildDAO.getInstance();
+    }
+
+    @Override
+    protected void execute(CommandEvent commandEvent) {
+        InternalGuild guild = guildDAO.getGuildById(commandEvent.getGuild().getId());
+        List<String> prefixes = guild.getPrefixList();
+
+        if (prefixes.isEmpty()) {
+            commandEvent.reply("There are not custom prefixes configured for this server. To add custom prefixes use the" +
+                    " `addprefix` command.\nDefault prefixes: `~` and <@" + commandEvent.getSelfUser().getId() + ">");
+            return;
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("The current custom prefixes are: \n");
+        for (String prefix : prefixes) {
+            sb.append("`").append(prefix).append("`").append("\n");
+        }
+        commandEvent.reply(sb.toString());
+    }
+}

--- a/src/main/java/com/bot/commands/settings/RemovePrefixCommand.java
+++ b/src/main/java/com/bot/commands/settings/RemovePrefixCommand.java
@@ -1,0 +1,45 @@
+package com.bot.commands.settings;
+
+import com.bot.db.GuildDAO;
+import com.bot.models.InternalGuild;
+import com.bot.utils.CommandCategories;
+import com.bot.utils.GuildUtils;
+import com.jagrosh.jdautilities.command.Command;
+import com.jagrosh.jdautilities.command.CommandEvent;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+public class RemovePrefixCommand extends Command {
+
+    private GuildDAO guildDAO;
+
+    public RemovePrefixCommand() {
+        this.name = "removeprefix";
+        this.help = "Removes one or more custom prefixes from the current custom prefixes.";
+        this.guildOnly = true;
+        this.arguments = "<One or more custom prefixes, separated by spaces>";
+        this.category = CommandCategories.MOD;
+
+        guildDAO = GuildDAO.getInstance();
+    }
+
+    @Override
+    protected void execute(CommandEvent commandEvent) {
+        InternalGuild guild = guildDAO.getGuildById(commandEvent.getGuild().getId());
+
+        if (commandEvent.getArgs().isEmpty()) {
+            commandEvent.reply(commandEvent.getClient().getWarning() + " You must specify at least one custom prefix to remove.");
+            return;
+        }
+
+        ArrayList<String> prefixes = guild.getPrefixList();
+        prefixes.removeAll(Arrays.asList(commandEvent.getArgs().split(" ")));
+
+        if (guildDAO.updateGuildPrefixes(commandEvent.getGuild().getId(), prefixes)) {
+            commandEvent.getMessage().addReaction(commandEvent.getClient().getSuccess()).queue();
+        } else {
+            commandEvent.reply(commandEvent.getClient().getError() + " Failed to update prefixes for server. Please contact a developer on the support server if this issue persists.");
+        }
+    }
+}

--- a/src/main/java/com/bot/commands/settings/RemovePrefixCommand.java
+++ b/src/main/java/com/bot/commands/settings/RemovePrefixCommand.java
@@ -3,7 +3,6 @@ package com.bot.commands.settings;
 import com.bot.db.GuildDAO;
 import com.bot.models.InternalGuild;
 import com.bot.utils.CommandCategories;
-import com.bot.utils.GuildUtils;
 import com.jagrosh.jdautilities.command.Command;
 import com.jagrosh.jdautilities.command.CommandEvent;
 

--- a/src/main/java/com/bot/db/DataLoader.java
+++ b/src/main/java/com/bot/db/DataLoader.java
@@ -26,11 +26,6 @@ public class DataLoader {
 		Config config = Config.getInstance();
 		long startTime = System.currentTimeMillis();
 
-		if (config.getConfig(Config.USE_DB).equals("False")) {
-			System.out.println("Use_DB Set to False in the config file. Exiting...");
-			return;
-		}
-
 		if (config.getConfig(Config.DB_URI) == null) {
 			System.out.println("DB_URI not set in the config file. Exiting...");
 			return;

--- a/src/main/java/com/bot/db/mappers/GuildMapper.java
+++ b/src/main/java/com/bot/db/mappers/GuildMapper.java
@@ -13,7 +13,8 @@ public class GuildMapper {
                 set.getString("min_base_role_id"),
                 set.getString("min_mod_role_id"),
                 set.getString("min_nsfw_role_id"),
-                set.getString("min_voice_role_id"));
+                set.getString("min_voice_role_id"),
+                set.getString("prefixes"));
     }
 
 }

--- a/src/main/java/com/bot/models/InternalGuild.java
+++ b/src/main/java/com/bot/models/InternalGuild.java
@@ -1,10 +1,10 @@
 package com.bot.models;
 
+import com.bot.preferences.GuildPreferencesProvider;
 import com.bot.utils.CommandCategories;
 import com.jagrosh.jdautilities.command.Command;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 public class InternalGuild {
 
@@ -12,8 +12,9 @@ public class InternalGuild {
     private String name;
     private int volume;
     private Map<Command.Category, String> roleRequirements;
+    private String prefixes;
 
-    public InternalGuild(String id, String name, int minVolume, String minBaseRole, String minModRole, String minNsfwRole, String minVoiceRole) {
+    public InternalGuild(String id, String name, int minVolume, String minBaseRole, String minModRole, String minNsfwRole, String minVoiceRole, String prefixes) {
         this.id = id;
         this.name = name;
         this.volume = minVolume;
@@ -22,6 +23,7 @@ public class InternalGuild {
         this.roleRequirements.put(CommandCategories.MOD, minModRole);
         this.roleRequirements.put(CommandCategories.NSFW, minNsfwRole);
         this.roleRequirements.put(CommandCategories.VOICE, minVoiceRole);
+        this.prefixes = prefixes;
     }
 
     public String getId() {
@@ -50,5 +52,25 @@ public class InternalGuild {
 
     public String getRequiredPermission(Command.Category category) {
         return roleRequirements.get(category);
+    }
+
+    public String getPrefixes() {
+        return prefixes;
+    }
+
+    public ArrayList<String> getPrefixList() {
+        if (prefixes == null)
+            return new ArrayList<>();
+
+        return new ArrayList<>(Arrays.asList(prefixes.split(" ")));
+    }
+
+    public GuildPreferencesProvider getGuildPreferencesProvider() {
+        // Return null if no prefixes are set
+        if(prefixes == null || prefixes.isEmpty())
+            return null;
+
+        // We use a space as a delimiter in the db as it is impossible for it to be uses in a prefix (as jda splits args using it)
+        return new GuildPreferencesProvider(Arrays.asList(prefixes.split(" ")), id);
     }
 }

--- a/src/main/java/com/bot/preferences/GuildCache.java
+++ b/src/main/java/com/bot/preferences/GuildCache.java
@@ -6,6 +6,7 @@ import org.apache.commons.collections4.MapIterator;
 import org.apache.commons.collections4.map.LRUMap;
 
 import java.util.ArrayList;
+import java.util.Map;
 import java.util.logging.Logger;
 
 /**
@@ -91,6 +92,13 @@ public class GuildCache {
     public void remove(String key) {
         synchronized (cacheMap) {
             cacheMap.remove(key);
+        }
+    }
+
+    public void removeAll() {
+        synchronized (cacheMap) {
+            for (Object entry : cacheMap.keySet())
+            cacheMap.remove((String) entry);
         }
     }
 

--- a/src/main/java/com/bot/preferences/GuildCache.java
+++ b/src/main/java/com/bot/preferences/GuildCache.java
@@ -1,0 +1,136 @@
+package com.bot.preferences;
+
+import com.bot.models.InternalGuild;
+import com.bot.utils.Config;
+import org.apache.commons.collections4.MapIterator;
+import org.apache.commons.collections4.map.LRUMap;
+
+import java.util.ArrayList;
+import java.util.logging.Logger;
+
+/**
+ * This is an in-memory cache for caching guild preferences. Since we will be getting the preferences on all messages sent on all channels vinny can see,
+ * this caching will be very important to help deal with the excessive load on the db.
+ * TODO: Eventually we should shift this off to something like redis.
+ */
+public class GuildCache {
+    private static final Logger LOGGER = Logger.getLogger(GuildCache.class.getName());
+
+    private static GuildCache instance;
+    private final LRUMap cacheMap;
+    private int MAX_SIZE;
+    private int CACHE_OBJECT_LIFETIME;
+    private int CACHE_CHECK_INTERVAL;
+
+
+    public static GuildCache getInstance() {
+        if (instance == null)
+            instance = new GuildCache();
+        return instance;
+    }
+
+    private GuildCache() {
+        Config config = Config.getInstance();
+        // Set or default the settings for the map
+        MAX_SIZE = config.getConfig(Config.GUILD_PREFS_CACHE_MAX_ITEMS) == null ? 500 : Integer.parseInt(config.getConfig(Config.GUILD_PREFS_CACHE_MAX_ITEMS));
+        CACHE_OBJECT_LIFETIME = config.getConfig(Config.GUILD_PREFS_CACHE_OBJECT_LIFETIME) == null ? 600 : Integer.parseInt(config.getConfig(Config.GUILD_PREFS_CACHE_OBJECT_LIFETIME));
+        CACHE_CHECK_INTERVAL = config.getConfig(Config.GUILD_PREFS_CACHE_CLEANUP_INTERVAL) == null ? 300 : Integer.parseInt(config.getConfig(Config.GUILD_PREFS_CACHE_CLEANUP_INTERVAL));
+
+        cacheMap = new LRUMap(MAX_SIZE);
+
+        // Starts a thread that will cleanup the cache every CHECK_INTERVAL seconds
+        if (CACHE_OBJECT_LIFETIME > 0 && CACHE_CHECK_INTERVAL > 0) {
+
+            Thread t = new Thread(() -> {
+                while (true) {
+                    try {
+                        Thread.sleep(CACHE_CHECK_INTERVAL * 1000);
+                    } catch (InterruptedException ex) {
+                    }
+                    cleanup();
+                }
+            });
+
+            t.setDaemon(true);
+            t.start();
+        }
+
+        LOGGER.info("Guild Cache successfully initialized.");
+    }
+
+    @SuppressWarnings("unchecked")
+    public void put(String key, InternalGuild value) {
+        synchronized (cacheMap) {
+            cacheMap.put(key, new GuildPreferencesCacheObject(value));
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public InternalGuild get(String key) {
+        synchronized (cacheMap) {
+            GuildPreferencesCacheObject cacheObject = (GuildPreferencesCacheObject) cacheMap.get(key);
+
+            if (cacheObject == null)
+                return null;
+            else {
+                cacheObject.lastAccessed = System.currentTimeMillis();
+                return cacheObject.value;
+            }
+        }
+    }
+
+    protected class GuildPreferencesCacheObject {
+        public long lastAccessed = System.currentTimeMillis();
+        public InternalGuild value;
+
+        GuildPreferencesCacheObject(InternalGuild value) {
+            this.value = value;
+        }
+    }
+
+    public void remove(String key) {
+        synchronized (cacheMap) {
+            cacheMap.remove(key);
+        }
+    }
+
+    public int size() {
+        synchronized (cacheMap) {
+            return cacheMap.size();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void cleanup() {
+
+        long now = System.currentTimeMillis();
+        ArrayList<String> deleteKey;
+
+        synchronized (cacheMap) {
+            MapIterator itr = cacheMap.mapIterator();
+
+            deleteKey = new ArrayList<>();
+            String key;
+            GuildPreferencesCacheObject cacheObject;
+
+            while (itr.hasNext()) {
+                key = (String) itr.next();
+                cacheObject = (GuildPreferencesCacheObject) itr.getValue();
+
+                if (cacheObject != null && (now > ((CACHE_OBJECT_LIFETIME * 1000) + cacheObject.lastAccessed))) {
+                    deleteKey.add(key);
+                }
+            }
+        }
+
+        for (String key : deleteKey) {
+            synchronized (cacheMap) {
+                cacheMap.remove(key);
+            }
+
+            Thread.yield();
+        }
+
+        LOGGER.info("Guild Cache cleanup complete. Removed " + deleteKey.size() + " stale guilds.");
+    }
+}

--- a/src/main/java/com/bot/preferences/GuildCache.java
+++ b/src/main/java/com/bot/preferences/GuildCache.java
@@ -34,7 +34,7 @@ public class GuildCache {
         // Set or default the settings for the map
         MAX_SIZE = config.getConfig(Config.GUILD_PREFS_CACHE_MAX_ITEMS) == null ? 500 : Integer.parseInt(config.getConfig(Config.GUILD_PREFS_CACHE_MAX_ITEMS));
         CACHE_OBJECT_LIFETIME = config.getConfig(Config.GUILD_PREFS_CACHE_OBJECT_LIFETIME) == null ? 600 : Integer.parseInt(config.getConfig(Config.GUILD_PREFS_CACHE_OBJECT_LIFETIME));
-        CACHE_CHECK_INTERVAL = config.getConfig(Config.GUILD_PREFS_CACHE_CLEANUP_INTERVAL) == null ? 300 : Integer.parseInt(config.getConfig(Config.GUILD_PREFS_CACHE_CLEANUP_INTERVAL));
+        CACHE_CHECK_INTERVAL = config.getConfig(Config.GUILD_PREFS_CACHE_CLEANUP_INTERVAL) == null ? 120 : Integer.parseInt(config.getConfig(Config.GUILD_PREFS_CACHE_CLEANUP_INTERVAL));
 
         cacheMap = new LRUMap(MAX_SIZE);
 

--- a/src/main/java/com/bot/preferences/GuildPreferencesManager.java
+++ b/src/main/java/com/bot/preferences/GuildPreferencesManager.java
@@ -19,11 +19,6 @@ public class GuildPreferencesManager implements GuildSettingsManager {
         cache = GuildCache.getInstance();
     }
 
-    @Override
-    public void init(){
-
-    }
-
     @Nullable
     @Override
     public GuildPreferencesProvider getSettings(Guild g) {

--- a/src/main/java/com/bot/preferences/GuildPreferencesManager.java
+++ b/src/main/java/com/bot/preferences/GuildPreferencesManager.java
@@ -1,0 +1,43 @@
+package com.bot.preferences;
+
+import com.bot.db.GuildDAO;
+import com.bot.models.InternalGuild;
+import com.jagrosh.jdautilities.command.GuildSettingsManager;
+import net.dv8tion.jda.core.entities.Guild;
+
+import javax.annotation.Nullable;
+import java.util.logging.Logger;
+
+public class GuildPreferencesManager implements GuildSettingsManager {
+    private static final Logger LOGGER = Logger.getLogger(GuildPreferencesManager.class.getName());
+
+    private GuildDAO guildDAO;
+    private GuildCache cache;
+
+    public GuildPreferencesManager() {
+        guildDAO = GuildDAO.getInstance();
+        cache = GuildCache.getInstance();
+    }
+
+    @Override
+    public void init(){
+
+    }
+
+    @Nullable
+    @Override
+    public GuildPreferencesProvider getSettings(Guild g) {
+        InternalGuild guild = cache.get(g.getId());
+
+        if (guild == null) {
+            guild = guildDAO.getGuildById(g.getId());
+            if (guild == null) {
+                // If guild is not in the db return nothing
+                LOGGER.warning("Guild not found in db when getting settings: " + g.getId());
+                return null;
+            }
+            cache.put(g.getId(), guild);
+        }
+        return guild.getGuildPreferencesProvider();
+    }
+}

--- a/src/main/java/com/bot/preferences/GuildPreferencesProvider.java
+++ b/src/main/java/com/bot/preferences/GuildPreferencesProvider.java
@@ -1,0 +1,22 @@
+package com.bot.preferences;
+
+import com.jagrosh.jdautilities.command.GuildSettingsProvider;
+
+import java.util.Collection;
+import java.util.List;
+
+public class GuildPreferencesProvider implements GuildSettingsProvider {
+
+    List<String> prefixes;
+    String guildId;
+
+    public GuildPreferencesProvider(List<String> prefixes, String guildId) {
+        this.prefixes = prefixes;
+        this.guildId = guildId;
+    }
+
+    @Override
+    public Collection<String> getPrefixes() {
+        return this.prefixes;
+    }
+}

--- a/src/main/java/com/bot/preferences/GuildPreferencesProvider.java
+++ b/src/main/java/com/bot/preferences/GuildPreferencesProvider.java
@@ -7,8 +7,8 @@ import java.util.List;
 
 public class GuildPreferencesProvider implements GuildSettingsProvider {
 
-    List<String> prefixes;
-    String guildId;
+    private List<String> prefixes;
+    private String guildId;
 
     public GuildPreferencesProvider(List<String> prefixes, String guildId) {
         this.prefixes = prefixes;

--- a/src/main/java/com/bot/utils/Config.java
+++ b/src/main/java/com/bot/utils/Config.java
@@ -25,7 +25,7 @@ public class Config {
     public static final String BOT_API_TOKEN = "BOT_PW_API";
 
 
-    public static final String USE_DB = "USE_DB";
+    public static final String SILENT_DEPLOY = "SILENT_DEPLOY";
     public static final String DB_URI = "DB_URI";
     public static final String DB_USERNAME = "DB_USERNAME";
     public static final String DB_PASSWORD = "DB_PASSWORD";
@@ -35,6 +35,9 @@ public class Config {
     public static final String PREFIX = "PREFIX";
     public static final String DATA_LOADER = "DATA_LOADER";
 
+    public static final String GUILD_PREFS_CACHE_MAX_ITEMS = "GUILD_PREFS_CACHE_MAX_ITEMS";
+    public static final String GUILD_PREFS_CACHE_OBJECT_LIFETIME = "GUILD_PREFS_OBJECT_LIFETIME";
+    public static final String GUILD_PREFS_CACHE_CLEANUP_INTERVAL = "GUILD_PREFS_CACHE_CLEANUP_INTERVAL";
 
     private Config() {
         this.configFile = new File("res/config/config.conf");

--- a/src/main/java/com/bot/utils/GuildUtils.java
+++ b/src/main/java/com/bot/utils/GuildUtils.java
@@ -3,6 +3,8 @@ package com.bot.utils;
 import net.dv8tion.jda.core.entities.Guild;
 import net.dv8tion.jda.core.entities.Role;
 
+import java.util.List;
+
 public class GuildUtils {
 
     public static Role getHighestRole(Guild guild) {
@@ -14,5 +16,15 @@ public class GuildUtils {
                 highest = r;
         }
         return highest;
+    }
+
+    public static String convertListToPrefixesString(List<String> prefixes) {
+        StringBuilder sb = new StringBuilder();
+        for (String prefix : prefixes) {
+            sb.append(prefix);
+            sb.append(" ");
+        }
+
+        return sb.toString();
     }
 }

--- a/src/main/resources/db/migration/V4__add_prefixes_for_guilds.sql
+++ b/src/main/resources/db/migration/V4__add_prefixes_for_guilds.sql
@@ -1,0 +1,2 @@
+ALTER TABLE guild
+ADD prefixes varchar(255) NULL DEFAULT NULL;

--- a/src/main/test/java/db/ChannelIT.java
+++ b/src/main/test/java/db/ChannelIT.java
@@ -36,8 +36,8 @@ public class ChannelIT {
 
 
     private List<InternalGuild> guilds = Arrays.asList(
-            new InternalGuild("101", "guild-1", 100, "1", "2", "2", "1"),
-            new InternalGuild("102", "guild-2", 100, "2", "2", "2", "3")
+            new InternalGuild("101", "guild-1", 100, "1", "2", "2", "1", "! v jk"),
+            new InternalGuild("102", "guild-2", 100, "2", "2", "2", "3", null)
     );
 
     private List<InternalTextChannel> textChannels = Arrays.asList(
@@ -112,6 +112,7 @@ public class ChannelIT {
             statement.setString(5, g.getRequiredPermission(CommandCategories.MOD));
             statement.setString(6, g.getRequiredPermission(CommandCategories.VOICE));
             statement.setString(7, g.getRequiredPermission(CommandCategories.NSFW));
+            statement.setString(8, g.getPrefixes());
 
             statement.addBatch();
         }

--- a/src/main/test/java/db/ChannelIT.java
+++ b/src/main/test/java/db/ChannelIT.java
@@ -100,7 +100,7 @@ public class ChannelIT {
     }
 
     private void loadGuilds() throws SQLException {
-        String query = "INSERT INTO guild(id, name, default_volume, min_base_role_id, min_mod_role_id, min_voice_role_id, min_nsfw_role_id) VALUES(?,?,?,?,?,?,?)";
+        String query = "INSERT INTO guild(id, name, default_volume, min_base_role_id, min_mod_role_id, min_voice_role_id, min_nsfw_role_id, prefixes) VALUES(?,?,?,?,?,?,?,?)";
         Connection connection = dataSource.getConnection();
         PreparedStatement statement = connection.prepareStatement(query);
 

--- a/src/main/test/java/db/GuildIT.java
+++ b/src/main/test/java/db/GuildIT.java
@@ -3,6 +3,7 @@ package db;
 import com.bot.db.GuildDAO;
 import com.bot.models.InternalGuild;
 import com.bot.models.InternalGuildMembership;
+import com.bot.preferences.GuildCache;
 import com.bot.utils.CommandCategories;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
@@ -82,6 +83,9 @@ public class GuildIT {
         resetdb();
         loadGuilds();
         loadUsers();
+
+        GuildCache cache = GuildCache.getInstance();
+        cache.removeAll();
     }
 
     private void resetdb() {
@@ -153,7 +157,6 @@ public class GuildIT {
     public void testGetGuildById() throws SQLException {
         InternalGuild expected = guilds.get(1); // Guild 102
         InternalGuild returned = guildDAO.getGuildById(expected.getId());
-
         assertGuildEquals(expected, returned);
     }
 

--- a/src/main/test/java/db/GuildIT.java
+++ b/src/main/test/java/db/GuildIT.java
@@ -41,8 +41,8 @@ public class GuildIT {
             );
 
     private List<InternalGuild> guilds = Arrays.asList(
-            new InternalGuild("101", "guild-1", 100, "1", "2", "2", "1"),
-            new InternalGuild("102", "guild-2", 100, "2", "2", "2", "3")
+            new InternalGuild("101", "guild-1", 100, "1", "2", "2", "1", null),
+            new InternalGuild("102", "guild-2", 100, "2", "2", "2", "3", "Dude ~ !")
     );
 
     @BeforeClass
@@ -102,6 +102,7 @@ public class GuildIT {
             statement.setString(5, g.getRequiredPermission(CommandCategories.MOD));
             statement.setString(6, g.getRequiredPermission(CommandCategories.VOICE));
             statement.setString(7, g.getRequiredPermission(CommandCategories.NSFW));
+            statement.setString(8, g.getPrefixes());
 
             statement.addBatch();
         }
@@ -158,7 +159,7 @@ public class GuildIT {
 
     @Test
     public void testAddGuild() throws SQLException {
-        InternalGuild expected = new InternalGuild("999", "test-added", 100, "999", "12345", "999", "999");
+        InternalGuild expected = new InternalGuild("999", "test-added", 100, "999", "12345", "999", "999", null);
         Role lowRole = mock(Role.class);
         Role highRole = mock(Role.class);
         List<Role> roles = Arrays.asList(lowRole, highRole);
@@ -191,7 +192,7 @@ public class GuildIT {
 
     @Test
     public void testUpdateMinBaseRole() throws SQLException {
-        InternalGuild expected = new InternalGuild("101", "guild-1", 100, "50", "2", "2", "1");
+        InternalGuild expected = new InternalGuild("101", "guild-1", 100, "50", "2", "2", "1", null);
         guildDAO.updateMinBaseRole("101", "50");
         InternalGuild returned = guildDAO.getGuildById(expected.getId());
         assertGuildEquals(expected, returned);
@@ -199,7 +200,7 @@ public class GuildIT {
 
     @Test
     public void testUpdateMinModRole() throws SQLException {
-        InternalGuild expected = new InternalGuild("101", "guild-1", 100, "1", "50", "2", "1");
+        InternalGuild expected = new InternalGuild("101", "guild-1", 100, "1", "50", "2", "1", null);
         guildDAO.updateMinModRole("101", "50");
         InternalGuild returned = guildDAO.getGuildById(expected.getId());
         assertGuildEquals(expected, returned);
@@ -208,7 +209,7 @@ public class GuildIT {
 
     @Test
     public void testUpdateMinNSFWRole() throws SQLException {
-        InternalGuild expected = new InternalGuild("101", "guild-1", 100, "1", "2", "50", "1");
+        InternalGuild expected = new InternalGuild("101", "guild-1", 100, "1", "2", "50", "1", null);
         guildDAO.updateMinNSFWRole("101", "50");
         InternalGuild returned = guildDAO.getGuildById(expected.getId());
         assertGuildEquals(expected, returned);
@@ -216,7 +217,7 @@ public class GuildIT {
 
     @Test
     public void testUpdateMinVoiceRole() throws SQLException {
-        InternalGuild expected = new InternalGuild("101", "guild-1", 100, "1", "2", "2", "50");
+        InternalGuild expected = new InternalGuild("101", "guild-1", 100, "1", "2", "2", "50", null);
         guildDAO.updateMinVoiceRole("101", "50");
         InternalGuild returned = guildDAO.getGuildById(expected.getId());
         assertGuildEquals(expected, returned);

--- a/src/main/test/java/db/GuildIT.java
+++ b/src/main/test/java/db/GuildIT.java
@@ -90,7 +90,7 @@ public class GuildIT {
     }
 
     private void loadGuilds() throws SQLException {
-        String query = "INSERT INTO guild(id, name, default_volume, min_base_role_id, min_mod_role_id, min_voice_role_id, min_nsfw_role_id) VALUES(?,?,?,?,?,?,?)";
+        String query = "INSERT INTO guild(id, name, default_volume, min_base_role_id, min_mod_role_id, min_voice_role_id, min_nsfw_role_id, prefixes) VALUES(?,?,?,?,?,?,?,?)";
         Connection connection = dataSource.getConnection();
         PreparedStatement statement = connection.prepareStatement(query);
 

--- a/src/main/test/java/db/PlaylistIT.java
+++ b/src/main/test/java/db/PlaylistIT.java
@@ -142,7 +142,7 @@ public class PlaylistIT {
     }
 
     private void loadGuilds() throws SQLException {
-        String query = "INSERT INTO guild(id, name, default_volume, min_base_role_id, min_mod_role_id, min_voice_role_id, min_nsfw_role_id) VALUES(?,?,?,?,?,?,?)";
+        String query = "INSERT INTO guild(id, name, default_volume, min_base_role_id, min_mod_role_id, min_voice_role_id, min_nsfw_role_id, prefixes) VALUES(?,?,?,?,?,?,?,?)";
         Connection connection = dataSource.getConnection();
         PreparedStatement statement = connection.prepareStatement(query);
 

--- a/src/main/test/java/db/PlaylistIT.java
+++ b/src/main/test/java/db/PlaylistIT.java
@@ -37,8 +37,8 @@ public class PlaylistIT {
     );
 
     private List<InternalGuild> guilds = Arrays.asList(
-            new InternalGuild("101", "guild-1", 100, "1", "2", "2", "1"),
-            new InternalGuild("102", "guild-2", 100, "2", "2", "2", "3")
+            new InternalGuild("101", "guild-1", 100, "1", "2", "2", "1", null),
+            new InternalGuild("102", "guild-2", 100, "2", "2", "2", "3", null)
     );
 
     private List<AudioTrack> tracks = Arrays.asList(


### PR DESCRIPTION
## Problem
- Bot prefix is static
- No caching of commonly queried guild properties
- No way to run another deployment silently in the background

## Solution
- Added the logic necessary to enforce custom prefixes
- Added an in memory cache of the most recently used guilds

## New Commands added
- addprefix
- prefixes
- removeprefix
